### PR TITLE
remove fallbacks

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,14 +23,6 @@ module.exports = {
     port: 8080,
     open: true,
   },
-  resolve: {
-    fallback: {
-      fs: false,
-      path: false,
-      os: false,
-      process: false,
-    },
-  },
   module: {
     rules: [
       {


### PR DESCRIPTION
Noticed that I don't need a fallback while working with [dotenv-webpack](https://www.npmjs.com/package/dotenv-webpack) module